### PR TITLE
Fix #266 correctly restore terminal parameters

### DIFF
--- a/bisect/bisect_test.go
+++ b/bisect/bisect_test.go
@@ -34,11 +34,11 @@ func TestBisectRight(t *testing.T) {
 }
 
 func BenchmarkRight(b *testing.B) {
-	rand.Seed(0)
+	r := rand.New(rand.NewSource(0))
 
 	for _, l := range []int{10, 1e2, 1e3, 1e4} {
-		x := rand.Perm(l)
-		insertion := rand.Int()
+		x := r.Perm(l)
+		insertion := r.Int()
 
 		b.Run(fmt.Sprintf("arrayLength=%d", l), func(b *testing.B) {
 			b.ResetTimer()

--- a/filter.go
+++ b/filter.go
@@ -22,8 +22,10 @@ func FilterContains(completions []Suggest, sub string, ignoreCase bool) []Sugges
 
 // FilterFuzzy checks whether the completion.Text fuzzy matches sub.
 // Fuzzy searching for "dog" is equivalent to "*d*o*g*". This search term
-// would match, for example, "Good food is gone"
-//                               ^  ^      ^
+// would match, for example:
+//
+//	"Good food is gone"
+//	    ^  ^      ^
 func FilterFuzzy(completions []Suggest, sub string, ignoreCase bool) []Suggest {
 	return filterSuggestions(completions, sub, ignoreCase, fuzzyMatch)
 }

--- a/key.go
+++ b/key.go
@@ -4,6 +4,7 @@
 package prompt
 
 // Key is the type express the key inserted from user.
+//
 //go:generate stringer -type=Key
 type Key int
 

--- a/reader_posix.go
+++ b/reader_posix.go
@@ -37,13 +37,11 @@ func (t *PosixReader) Open() error {
 
 // Close should be called after stopping input
 func (t *PosixReader) Close() error {
-	if err := syscall.Close(t.fd); err != nil {
-		return err
-	}
 	if err := term.Restore(); err != nil {
+		_ = syscall.Close(t.fd)
 		return err
 	}
-	return nil
+	return syscall.Close(t.fd)
 }
 
 // Read returns byte array.

--- a/term/raw.go
+++ b/term/raw.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term
@@ -6,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/pkg/term/termios"
-	"golang.org/x/sys/unix"
 )
 
 // SetRaw put terminal into a raw mode
@@ -25,5 +25,5 @@ func SetRaw(fd int) error {
 	n.Cc[syscall.VMIN] = 1
 	n.Cc[syscall.VTIME] = 0
 
-	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, (*unix.Termios)(&n))
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, n)
 }

--- a/term/term.go
+++ b/term/term.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package term
@@ -10,18 +11,28 @@ import (
 )
 
 var (
-	saveTermios     *unix.Termios
+	saveTermios     unix.Termios
+	saveTermiosErr  error
 	saveTermiosFD   int
 	saveTermiosOnce sync.Once
 )
 
-func getOriginalTermios(fd int) (unix.Termios, error) {
-	var err error
+func getOriginalTermios(fd int) (*unix.Termios, error) {
 	saveTermiosOnce.Do(func() {
 		saveTermiosFD = fd
-		saveTermios, err = termios.Tcgetattr(uintptr(fd))
+		var v *unix.Termios
+		v, saveTermiosErr = termios.Tcgetattr(uintptr(fd))
+		if saveTermiosErr == nil {
+			// save a copy
+			saveTermios = *v
+		}
 	})
-	return *saveTermios, err
+	if saveTermiosErr != nil {
+		return nil, saveTermiosErr
+	}
+	// return a copy
+	v := saveTermios
+	return &v, nil
 }
 
 // Restore terminal's mode.
@@ -30,5 +41,5 @@ func Restore() error {
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, &o)
+	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
 }


### PR DESCRIPTION
I originally created this PR to address https://github.com/c-bata/go-prompt/issues/266, but it looks like this fork [already had a fix](https://github.com/elk-language/go-prompt/commit/7fe657d6d0ccf276c07c2e5307b99b5b968d2f1a), which was for https://github.com/c-bata/go-prompt/issues/228.

There was an additional bug, however - the file descriptor was being closed prior to restoring the terminal parameters. I assume that meant that the restore itself did nothing.

This also fixes a nearby code error that's unlikely to cause any actual issues.
I also addressed a staticcheck lint issue.