### PR TITLE
Fix restoring terminal - pass down and use fd

### DIFF
--- a/reader_posix.go
+++ b/reader_posix.go
@@ -37,7 +37,7 @@ func (t *PosixReader) Open() error {
 
 // Close should be called after stopping input
 func (t *PosixReader) Close() error {
-	if err := term.Restore(); err != nil {
+	if err := term.RestoreFD(t.fd); err != nil {
 		_ = syscall.Close(t.fd)
 		return err
 	}

--- a/term/term.go
+++ b/term/term.go
@@ -37,9 +37,14 @@ func getOriginalTermios(fd int) (*unix.Termios, error) {
 
 // Restore terminal's mode.
 func Restore() error {
-	o, err := getOriginalTermios(saveTermiosFD)
+	return RestoreFD(saveTermiosFD)
+}
+
+// RestoreFD restores terminal's mode for the given file descriptor.
+func RestoreFD(fd int) error {
+	o, err := getOriginalTermios(fd)
 	if err != nil {
 		return err
 	}
-	return termios.Tcsetattr(uintptr(saveTermiosFD), termios.TCSANOW, o)
+	return termios.Tcsetattr(uintptr(fd), termios.TCSANOW, o)
 }


### PR DESCRIPTION
When using the `Input` method, the file descriptor may not be the one that was originally cached (when the tty config was saved), which can result in it failing to restore / leaving the tty in raw mode.

Perhaps it would have been better to make it take a snapshot of the tty config for that specific file descriptor. This was the easiest fix, though.