### PR TITLE
Add HistoryInterface to let users replace the default history with custom implementation.

### DIFF
--- a/constructor.go
+++ b/constructor.go
@@ -224,7 +224,19 @@ func WithMaxSuggestion(x uint16) Option {
 // WithHistory to set history expressed by string array.
 func WithHistory(x []string) Option {
 	return func(p *Prompt) error {
-		p.history.histories = x
+		if history, ok := p.history.(*History); ok {
+			history.histories = x
+			history.Clear()
+		}
+
+		return nil
+	}
+}
+
+// WithCustomHistory to set use of own history implementation.
+func WithCustomHistory(history HistoryInterface) Option {
+	return func(p *Prompt) error {
+		p.history = history
 		p.history.Clear()
 		return nil
 	}

--- a/history.go
+++ b/history.go
@@ -4,6 +4,14 @@ import (
 	istrings "github.com/elk-language/go-prompt/strings"
 )
 
+// HistoryInterface lets users repalce the build in history.
+type HistoryInterface interface {
+	Add(string)
+	Clear()
+	Older(*Buffer, istrings.Width, int) (*Buffer, bool)
+	Newer(*Buffer, istrings.Width, int) (*Buffer, bool)
+}
+
 // History stores the texts that are entered.
 type History struct {
 	histories []string

--- a/prompt.go
+++ b/prompt.go
@@ -46,7 +46,7 @@ type Prompt struct {
 	buffer                 *Buffer
 	renderer               *Renderer
 	executor               Executor
-	history                *History
+	history                HistoryInterface
 	lexer                  Lexer
 	completion             *CompletionManager
 	keyBindings            []KeyBind


### PR DESCRIPTION
This lets users implement History and do custom .Add actions instead of the default behavior..
```go
type History struct {
	histories []string
	tmp       []string
	selected  int
}

// Add to add text in history.
func (h *History) Add(input string) {
	var histories []string
	for _, history := range h.histories {
		if history != input {
			histories = append(histories, history)
		}
	}

	h.histories = append(histories, input)
	h.Clear()
}
...
// NewHistory returns new history object.
func NewHistory() *History {
	return &History{
		histories: []string{},
		tmp:       []string{""},
		selected:  0,
	}
}
```
or

```go
type History struct {
	histories []string
	tmp       []string
	selected  int
}
// Add to add text in history.
func (h *History) Add(input string) {
	if len(h.histories) < 1 || h.histories[len(h.histories)-1] != input {
		h.histories = append(h.histories, input)
		h.Clear()
	}
}
...
// NewHistory returns new history object.
func NewHistory() *History {
	return &History{
		histories: []string{},
		tmp:       []string{""},
		selected:  0,
	}
}
```

And then can be used as
```go
p := prompt.New(
	executor,
	prompt.WithCustomHistory(NewHistory()),
)

p.Run()
```