### PR TITLE
Move cursor to correct position when completing

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -199,7 +199,7 @@ func (r *Renderer) renderCompletion(buf *Buffer, completions *CompletionManager)
 	}
 
 	if x+width >= r.col {
-		r.out.CursorForward(int(x + width - r.col))
+		r.out.CursorForward(int(x + width - r.col + 1))
 	}
 
 	r.out.CursorUp(windowHeight)


### PR DESCRIPTION
When the suggestion box cannot fit to the right of the cursor (i.e.
`x + width >= col`), `renderCompletion` moved the cursor forward by
`x + width - col` columns. That is one short: the cursor ended up one
position to the left of where it should be, causing a visual glitch
on narrow terminals.

Fix: add 1 to the `CursorForward` argument so the cursor lands on    
the correct column.