### PR TITLE
Fix duplicated suggestion on commit for separator-containing completions

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -346,7 +346,20 @@ keySwitch:
 		p.buffer.DeleteBeforeCursorRunes(istrings.RuneNumber(p.renderer.indentSize), cols, rows)
 		return true
 	default:
-		if s, ok := p.completion.GetSelectedSuggestion(); ok {
+		if s, ok := p.completion.GetSelectedSuggestion(); ok &&
+			!strings.HasSuffix(p.buffer.Document().TextBeforeCursor(), s.Text) {
+			// Normally the selected suggestion has already been written into the
+			// buffer by the live inline preview (see updateSuggestions), so its
+			// text is the suffix of the line before the cursor and there is
+			// nothing to do here. The previous implementation unconditionally
+			// deleted the word before the cursor and re-inserted the suggestion;
+			// that duplicated any suggestion containing the completion word
+			// separator, e.g. a quoted path with spaces ("file with space.txt"),
+			// turning `rm "file with space.txt"` into
+			// `rm "file with "file with space.txt"` on commit.
+			//
+			// Keep the re-insertion only as a fallback for the (normally
+			// unreachable) case where the inline preview is not present.
 			w := p.buffer.Document().GetWordBeforeCursorUntilSeparator(p.completion.wordSeparator)
 			if w != "" {
 				p.buffer.DeleteBeforeCursorRunes(istrings.RuneCountInString(w), cols, rows)
@@ -503,8 +516,10 @@ func (p *Prompt) Input() string {
 	}
 }
 
-const IndentUnit = ' '
-const IndentUnitString = string(IndentUnit)
+const (
+	IndentUnit       = ' '
+	IndentUnitString = string(IndentUnit)
+)
 
 func (p *Prompt) readBuffer(bufCh chan []byte, stopCh chan struct{}) {
 	debug.Log("start reading buffer")

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -1,0 +1,84 @@
+package prompt
+
+import (
+	"testing"
+
+	istrings "github.com/elk-language/go-prompt/strings"
+)
+
+// quotedSuggestion is a completion candidate that contains the completion word
+// separator (a space). Committing such a suggestion is exactly the case that
+// previously got duplicated on the command line.
+const quotedSuggestion = `"file with space.txt"`
+
+// newCompletionTestPrompt builds a Prompt wired with a completer that always
+// offers a single suggestion replacing the range [start, cursor], and with a
+// renderer sized like a normal terminal so buffer edits behave normally.
+func newCompletionTestPrompt(suggestion string, start istrings.RuneNumber) *Prompt {
+	p := New(
+		NoopExecutor,
+		WithPrefix(""),
+		WithCompleter(func(d Document) ([]Suggest, istrings.RuneNumber, istrings.RuneNumber) {
+			return []Suggest{{Text: suggestion}}, start, d.CurrentRuneIndex()
+		}),
+	)
+	p.renderer.col = DefColCount
+	p.renderer.row = DefRowCount
+
+	return p
+}
+
+// TestCompletionCommitDoesNotDuplicateQuotedSuggestion reproduces the reported
+// bug: selecting a quoted path with spaces via Tab (which writes the inline
+// preview into the buffer) and then committing it must leave the line intact
+// instead of duplicating the suggestion.
+func TestCompletionCommitDoesNotDuplicateQuotedSuggestion(t *testing.T) {
+	p := newCompletionTestPrompt(quotedSuggestion, 3)
+
+	p.buffer.InsertTextMoveCursor("rm ", DefColCount, DefRowCount, false)
+	p.completion.Update(*p.buffer.Document())
+
+	// Tab selects the suggestion; the inline preview inserts it into the buffer.
+	p.handleCompletionKeyBinding(nil, Tab, p.completion.Completing())
+
+	want := "rm " + quotedSuggestion
+	if got := p.buffer.Text(); got != want {
+		t.Fatalf("after Tab preview: buffer = %q, want %q", got, want)
+	}
+
+	// Enter commits the selection and must not re-insert (duplicate) the text.
+	p.handleCompletionKeyBinding(nil, Enter, p.completion.Completing())
+
+	if got := p.buffer.Text(); got != want {
+		t.Fatalf("after commit: buffer = %q, want %q", got, want)
+	}
+}
+
+// TestCompletionCommitWithoutPreviewInsertsSuggestion covers the defensive
+// fallback: if a suggestion is selected without the inline preview having
+// written it into the buffer, committing must still insert it (replacing the
+// partially typed token) rather than silently do nothing.
+func TestCompletionCommitWithoutPreviewInsertsSuggestion(t *testing.T) {
+	p := newCompletionTestPrompt(quotedSuggestion, 3)
+
+	// A partially typed token, cursor at the end.
+	p.buffer.InsertTextMoveCursor(`rm "fi`, DefColCount, DefRowCount, false)
+	p.completion.Update(*p.buffer.Document())
+
+	// Select directly, bypassing updateSuggestions, so no inline preview is
+	// written to the buffer.
+	p.completion.Next()
+
+	if !p.completion.Completing() {
+		t.Fatal("expected a suggestion to be selected")
+	}
+
+	// The line before the cursor does not yet end with the suggestion, so the
+	// fallback must replace the partial token with the full suggestion.
+	p.handleCompletionKeyBinding(nil, Enter, p.completion.Completing())
+
+	want := "rm " + quotedSuggestion
+	if got := p.buffer.Text(); got != want {
+		t.Fatalf("after commit without preview: buffer = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
When a completion was committed (e.g. by pressing Enter) the default case of handleCompletionKeyBinding unconditionally deleted the word before the cursor (split on the completion word separator) and re-inserted the selected suggestion. The live inline preview has already written the full suggestion into the buffer, so for any suggestion containing the word separator this duplicated part of it: `rm "file with space.txt"` became `rm "file with "file with space.txt"`